### PR TITLE
removed unsuported architectures from PosixSemaphore. Changed the def…

### DIFF
--- a/include/sys/CancelableThread.h
+++ b/include/sys/CancelableThread.h
@@ -70,7 +70,12 @@ namespace itc
         {
           pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL);
           pthread_setcanceltype(PTHREAD_CANCEL_DEFERRED, NULL);
-          mRunnable.get()->execute();
+          try{
+            mRunnable.get()->execute();
+          }catch(const std::exception& e)
+          {
+            itc::getLog()->error(__FILE__,__LINE__,"Exception in itc::abstract::IRunnable::execute(): %s",e.what());
+          }
         }
         pthread_cleanup_pop(0);
       }
@@ -93,7 +98,12 @@ namespace itc
       {
         if(!isfinished.load()) // there is an attempt to call this destructor more then once. It seems that CancelableThread holding shared_ptr is split in two independent ones.
         {
-          cleanup(); // cleanup first then call cancel
+          try{
+            cleanup(); // cleanup first then call cancel
+          }catch(const std::exception& e)
+          {
+            itc::getLog()->error(__FILE__,__LINE__,"Exception in itc::abstract::IRunnable::~Specific_Destructor(): %s",e.what());
+          }
           cancel();
           finish();
           getLog()->flush();

--- a/include/sys/PosixSemaphore.h
+++ b/include/sys/PosixSemaphore.h
@@ -37,159 +37,6 @@ namespace itc
 {
   namespace sys
   {
-    /**
-     * POSIX.1-2001 and POSIX.1-2004 specificatios (IEEE Std 1003.1, 2001,2004 Edition)
-     * is a bit ambigous about sem_wait/sem_destroy/sem_get_value.
-     * 
-     * 1. EINVAL parameter became  optional since 2001.
-     * 
-     * An undefined behavior at destroying semaphores, on those some threads are waiting is a plague.
-     * The implementations are not required to define fixed behavior or condition in above case. 
-     * In addition EBUSY return value is specified as an option.
-     * 
-     * There are 3 problems in most of implementations:
-     * 2. sem_getvalue(sem_t* sem,int* val) have dual behavior (by specification Edition 2001) in returning 
-     * of value if there are threads waiting on semaphore. Either negative value set to val or 0.
-     *    First behavior is exceptionally soficient for any needs, however second one sux.
-     * 
-     * 3. sem_destroy() has undefined behavior on trys to destroy a semmaphore on which another threads are blocking. 
-     *    returning -1 and set errno to EBUSY is optional :(
-     * 
-     * 4. sem_wait() Edition 2004 says nothing about behavior related to (3) and EINVAL became an option.
-     *    Good news returning -1 and seting errno to EINTR is not an option and we can use it to our adventages.
-     *  
-     * Linux implementation:
-     *  Linux kernel 2.6.16 and glibc-2.4 (latest i have tested) have second behavior for sem_getvalue. 
-     *  sem_count is defined as unsigned int and never drops below 0. No additional count 
-     *  for threads waiting on semaphore. You can never get the value of threads waiting.      
-     *  sem_destroy always return 0 and makes nothing more. Just return 0 !!!. 
-     *  There is no code for semaphore invalidation. conclusion: it sux.
-     * 
-     * Pthread-win32 implementation is much better in this case. It has specified EBUSY and safe behavior 
-     * for semaphores destroying. sem_getvalue returns negative value in case there are threads blocking on 
-     * semaphore - :aplause.  
-     * 
-     * FreeBSD implementation conforms to POSIX.1-1996 and has same sucking behavior for sem_getvalue as linux has.
-     * The safety of sem_destroy is just same as Pthread-win32 has. Instead of destroying semaphore that is 
-     * blocked by other threads -1 is returned and errno set to EBUSY. 
-     * sem_wait is non interraptible :(
-     * Conclusion: better then nothing.
-     * 
-     * 
-     * Solaris 9 (SunOS 5.9) implementation:
-     * sem_destroy - undefined behavior by destroying of semaphores those are blocked by another threads.
-     * sem_getvalue - set value to 0 or positive number - same sux as under linux.
-     * sem_wait - interraptible.
-     * 
-     * 
-     * However sem_wait is defined as a cancellation point. so that should not be a problem to break 
-     * sem_wait if we use pthread_cancel() with pthread_cleanup_push() and pthread_cleanup_pop().
-     * This should be done in the thread not in the semaphore classes. Take itc::sys::CancelableThread 
-     * for this purposes.
-     * 
-     **/
-
-#  if defined(_MSC_VER) && (defined(__MINGW32_VERSION))
-#if !defined(__PTPS__)
-#    define __PTPS__
-
-    /**
-     * Like RawPosixSemaphore. Should be used with pthread for win32 (best pthread 
-     * realization ever). 
-     * 
-     **/
-
-    class PosixSemaphore
-    {
-     private:
-      sem_t semaphore;
-     public:
-
-      explicit PosixSemaphore(ulong def_val = 0)
-      {
-        if(sem_init(&semaphore, 0, def_val))
-          throw ITCException(errno, exceptions::Can_not_initialize_semaphore);
-      }
-
-      explicit PosixSemaphore(const PosixSemaphore& ref)
-      {
-        // seak idea to make a copy of semaphore.
-        throw ITCException(errno, exceptions::Can_not_copy_semaphore);
-      }
-
-      inline void wait(void)
-      {
-        if(sem_wait(&semaphore) == -1)
-        {
-          throw ITCException(exceptions::Can_not_wait_on_semaphore, EINVAL);
-        }
-      }
-
-      inline void timedWait(const ::timespec& timeout)
-      {
-        if(sem_timedwait(&semaphore, &timeout) == -1)
-        {
-          throw ITCException(exceptions::Can_not_wait_on_semaphore, errno);
-        }
-      }
-
-      inline int tryWait(void)
-      {
-        register int ret = sem_trywait(&semaphore);
-
-        if(ret == -1)
-        {
-          if(errno == EAGAIN)
-          {
-            return EAGAIN;
-          }
-          throw ITCException(EINVAL, exceptions::Can_not_wait_on_semaphore);
-        }
-
-        return 0;
-      }
-
-      inline void post(void)
-      {
-        if(sem_post(&semaphore) == -1)
-        {
-          throw ITCException(exceptions::Can_not_wait_on_semaphore, errno);
-        }
-      }
-
-      inline int getValue(void)
-      {
-        register int value; // is on stack ... should be thread safe ...
-
-        if(sem_getvalue(&semaphore, &value))
-        {
-          throw ITCException(exceptions::Can_not_get_semaphore_value, errno);
-        }
-
-        return value;
-      }
-
-      inline void destroy()
-      {
-        while((sem_destroy(&semaphore) == -1) && (errno == EBUSY))
-        {
-          int value = 0;
-          if(sem_getvalue(&semaphore, &value) != -1)
-          {
-            sem_post_multiple(&semaphore, value); // Cancellation still required, wake all waiting threads !
-          }
-        }
-      }
-
-      ~PosixSemaphore()
-      {
-        destroy();
-      }
-    };
-#endif
-#  else
-#if !defined(__RPS__)
-#    define __RPS__
 
     /**
      * This class is safe to use with the itc::sys::CancelableThread class. 
@@ -197,10 +44,8 @@ namespace itc
      * you can experience undefined behavior by destroying instances of this
      * class when other threads waiting on this semaphore.
      * 
-     * Update: all other archs are broken now. Interface change.
-     * 
      **/
-    class RawPosixSemaphore
+    class POSIXSemaphore
     {
      private:
       mutable sem_t semaphore;
@@ -208,15 +53,15 @@ namespace itc
      public:
       
 
-      explicit RawPosixSemaphore(ulong def_val = 0): valid{false}
+      explicit POSIXSemaphore(ulong def_val = 0): valid{false}
       {
         if(sem_init(&semaphore, 0, def_val))
           throw std::system_error(errno, std::system_category(), "RawPosixSemaphore::RawPosixSemaphore(): semaphore initialization failed");
         valid.store(true);
       }
 
-      explicit RawPosixSemaphore(const RawPosixSemaphore&) = delete;
-      explicit RawPosixSemaphore(RawPosixSemaphore&) = delete;
+      explicit POSIXSemaphore(const POSIXSemaphore&) = delete;
+      explicit POSIXSemaphore(POSIXSemaphore&) = delete;
 
       const bool wait(void) const
       {
@@ -271,9 +116,9 @@ namespace itc
         {
           valid.store(false);
           // an attempt to release all the waiting threads
-          // subscribers must check the return code
-          // limited to 10000 subscribers ...
-          for(auto i=0;i<10000;++i)
+          // subscribers must check the return code.
+          // limited to 1000 subscribers ...
+          for(auto i=0;i<1000;++i)
           {
             sem_post(&semaphore);
           }
@@ -283,24 +128,12 @@ namespace itc
         }
       }
 
-      ~RawPosixSemaphore() noexcept
+      ~POSIXSemaphore() noexcept
       {
         destroy();
       }
     };
-#  endif
-#endif
-
-#  if defined (__RPS__)
-    typedef RawPosixSemaphore Semaphore;
-#  else 
-#    if defined (__PTPS__)
-    typedef PosixSemaphore Semaphore;
-#    endif
-#  endif
   }
 }
-
-
 
 #endif

--- a/include/sys/Thread.h
+++ b/include/sys/Thread.h
@@ -24,7 +24,7 @@
 
 #include <abstract/Cleanable.h>
 #include <abstract/Runnable.h>
-#include <sys/PosixSemaphore.h>
+#include <sys/semaphore.h>
 #include <sys/prototypes.h>
 #include <InterfaceCheck.h>
 #include <sys/synclock.h>
@@ -63,7 +63,8 @@ namespace itc
     protected:
       friend void* invoke(Thread*);
     private:
-      Semaphore start;
+      using semaphore=::itc::sys::semaphore<0>; // fallback to posix semaphore
+      semaphore start;
       pthread_t TID;
 
     private:

--- a/nbproject/private/private.xml
+++ b/nbproject/private/private.xml
@@ -8,9 +8,9 @@
     <editor-bookmarks xmlns="http://www.netbeans.org/ns/editor-bookmarks/2" lastBookmarkId="0"/>
     <open-files xmlns="http://www.netbeans.org/ns/projectui-open-files/2">
         <group>
+            <file>file:/home/pk/workspace/docker/luadev.env/workspace/ITCLib/include/sys/synclock.h</file>
             <file>file:/home/pk/workspace/docker/luadev.env/workspace/ITCLib/include/sys/mutex.h</file>
             <file>file:/home/pk/workspace/docker/luadev.env/workspace/ITCLib/include/sys/semaphore.h</file>
-            <file>file:/home/pk/workspace/docker/luadev.env/workspace/ITCLib/include/sys/PosixSemaphore.h</file>
         </group>
     </open-files>
 </project-private>

--- a/src/Thread.cpp
+++ b/src/Thread.cpp
@@ -52,8 +52,13 @@ namespace itc {
             sigaddset(&nset, SIGTERM);
             pthread_sigmask(SIG_BLOCK, &nset, NULL);
 #endif
-            context->start.wait();
-            context->run();
+            try{
+              context->start.wait();
+              context->run();
+            }catch(const std::exception& e)
+            {
+              itc::getLog()->fatal(__FILE__,__LINE__,"Thread::invoke() has failed because of an exception: %s",e.what());
+            }
             return NULL;
         }
     }


### PR DESCRIPTION
default usage to itc::sys::sempahore(lightweith semaphore with fallback to POSIX semaphore) in all the client code, added additional exception handling related to itc::sys::semaphore wherever applicable.
itc::sys::Nap will use POSIX nanosleep instead of semaphore-emulated version.